### PR TITLE
wording regarding empty routing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For our chat app,
  }
 </pre>
 
-2. Then bind the queue to chatExchange  w/ "#" or "" 'Binding key' and listen to ALL messages.
+2. Then bind the queue to chatExchange with an empty 'Binding key' and listen to ALL messages.
 <pre>
  q.bind('chatExchange', "");
 </pre>


### PR DESCRIPTION
It's an error to use the `#` binding key with fanout exchanges with the intent of routing all the messages to the bound queues. Not because it won't work, but because it has no effect on it since you are using a fanout exchange. Patterns are only reserved for the topic exchange.
